### PR TITLE
Added yaml config for Aruba 6300M to Thola

### DIFF
--- a/config/device-classes/generic/aruba.yaml
+++ b/config/device-classes/generic/aruba.yaml
@@ -1,0 +1,85 @@
+name: aruba
+
+config:
+  components:
+    cpu: true
+    memory: true
+    disk: true
+    server: true
+
+match:
+  logical_operator: "OR"
+  conditions:
+    - type: SysObjectID
+      match_mode: startsWith
+      values:
+        - ".1.3.6.1.4.1.47196"
+
+identify:
+  properties:
+    vendor:
+      - detection: constant
+        value: "HPE Aruba"
+    model:
+      - detection: SysDescription
+        operators:
+          - type: modify
+            modify_method: regexSubmatch
+            regex: '^Aruba ([^,]+)'
+            format: "$1"
+    serial_number:
+      - detection: snmpget
+        oid: .1.3.6.1.2.1.47.1.1.1.1.11.1
+    os_version:
+      - detection: SysDescription
+        operators:
+          - type: modify
+            modify_method: regexSubmatch
+            regex: 'Swch ([^,]+)'
+            format: "$1"
+
+components:
+  cpu:
+    load:
+      - detection: snmpget
+        oid: ".1.3.6.1.2.1.25.3.3.1.2.196608"
+  memory:
+    usage:
+      - detection: snmpget
+        oid: ".1.3.6.1.2.1.25.2.3.1.6.6"
+        operators:
+          - type: modify
+            modify_method: divide
+            value:
+              detection: snmpget
+              oid: ".1.3.6.1.2.1.25.2.3.1.5.6"
+              operators:
+                - type: modify
+                  modify_method: divide
+                  value:
+                    detection: constant
+                    value: 100
+  disk:
+    storages:
+      detection: snmpwalk
+      values:
+        type:
+          oid: ".1.3.6.1.2.1.25.2.3.1.2"
+          operators:
+            - type: modify
+              modify_method: map
+              mappings: hrStorageType.yaml
+        description:
+          oid: ".1.3.6.1.2.1.25.2.3.1.3"
+        available:
+          oid: ".1.3.6.1.2.1.25.2.3.1.5"
+        used:
+          oid: ".1.3.6.1.2.1.25.2.3.1.6"
+  server:
+    procs:
+      - detection: snmpget
+        oid: ".1.3.6.1.2.1.25.1.7.0"
+    users:
+      - detection: snmpget
+        oid: ".1.3.6.1.2.1.25.1.5.0"
+


### PR DESCRIPTION
This config adds HPE Aruba switches to Thola. The devices have the SysobjectID 1.3.6.1.4.1.47196.
I will send the snmprec file via mail.